### PR TITLE
Add support for named tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Example of usage:
 
 6. Generate tests with [gotests](https://github.com/cweill/gotests)
 
-Generate one test for spesific function/method:
+Generate one test for a specific function/method:
 
 ```vim
 :GoTestAdd

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For named tests to work you have to install gotests from develop branch, for exa
 })
 ```
 
-Or using `vim.fn.jobstart` on build:
+Or by calling `vim.fn.jobstart`:
 
 ```lua
 vim.fn.jobstart("go install github.com/cweill/gotests/...@develop")

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ use {
 }
 ```
 
+Lazy.nvim:
+
+```lua
+return {
+  "olexsmir/gopher.nvim",
+  build = function ()
+    vim.cmd(":GoInstallDeps")
+    -- make named tests works
+    vim.fn.jobstart("go install github.com/cweill/gotests/...@develop")
+  end,
+  config = function ()
+    require("gopher").setup({
+      gotests = {
+        template = "testify",
+        named = true
+      }
+    })
+  end
+}
+```
+
 Also, run `TSInstall go` if `go` parser if isn't installed yet.
 
 ## Config
@@ -40,8 +61,6 @@ require("gopher").setup {
     iferr = "iferr",
   },
   gotests = {
-    -- gotests tag to install from
-    tag = "@latest",
     -- gotests doesn't have template named "default" so this plugin uses "default" to set the default template
     template = "default",
     -- path to a directory containing custom test code templates

--- a/README.md
+++ b/README.md
@@ -20,27 +20,6 @@ use {
 }
 ```
 
-Lazy.nvim:
-
-```lua
-return {
-  "olexsmir/gopher.nvim",
-  build = function ()
-    vim.cmd(":GoInstallDeps")
-    -- make named tests works
-    vim.fn.jobstart("go install github.com/cweill/gotests/...@develop")
-  end,
-  config = function ()
-    require("gopher").setup({
-      gotests = {
-        template = "testify",
-        named = true
-      }
-    })
-  end
-}
-```
-
 Also, run `TSInstall go` if `go` parser if isn't installed yet.
 
 ## Config
@@ -71,6 +50,35 @@ require("gopher").setup {
   },
 }
 ```
+
+### Named tests with testify (using map instead of slice for test cases)
+
+```lua
+require("gopher").setup({
+  gotests = {
+    template = "testify",
+    named = true
+  }
+})
+```
+
+For named tests to work you have to install gotests from develop branch, for example using [mason-tool-installer](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim):
+
+```lua
+ require('mason-tool-installer').setup({
+  ensure_installed = {
+    { "gotests", version = "develop" },
+  }
+})
+```
+
+Or using `vim.fn.jobstart` on build:
+
+```lua
+vim.fn.jobstart("go install github.com/cweill/gotests/...@develop")
+```
+
+If you're using `lazy.nvim` you can put in `build` function inside `setup()`
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ require("gopher").setup {
     impl = "impl",
     iferr = "iferr",
   },
+  gotests = {
+    -- gotests tag to install from
+    tag = "@latest",
+    -- gotests doesn't have template named "default" so this plugin uses "default" to set the default template
+    template = "default",
+    -- path to a directory containing custom test code templates
+    template_dir = nil,
+    -- switch table tests from using slice to map (with test name for the key)
+    -- works only with gotests installed from develop branch
+    named = false,
+  },
 }
 ```
 

--- a/lua/gopher/config.lua
+++ b/lua/gopher/config.lua
@@ -20,7 +20,7 @@ local default_config = {
     iferr = "iferr",
     dlv = "dlv",
   },
-  ---@class gopjer.ConfigGotests
+  ---@class gopher.ConfigGotests
   gotests = {
     -- gotests doesn't have template named "default" so this plugin uses "default" to set the default template
     template = "default",

--- a/lua/gopher/config.lua
+++ b/lua/gopher/config.lua
@@ -22,12 +22,16 @@ local default_config = {
   },
   ---@class gopher.ConfigGotests
   gotests = {
+    -- gotests tag to install from
+    ---@type string
+    tag = "@latest",
     -- gotests doesn't have template named "default" so this plugin uses "default" to set the default template
     template = "default",
     -- path to a directory containing custom test code templates
     ---@type string|nil
     template_dir = nil,
     -- switch table tests from using slice to map (with test name for the key)
+    -- works only with gotests installed from develop branch
     ---@type boolean
     named = false,
   },

--- a/lua/gopher/config.lua
+++ b/lua/gopher/config.lua
@@ -22,9 +22,6 @@ local default_config = {
   },
   ---@class gopher.ConfigGotests
   gotests = {
-    -- gotests tag to install from
-    ---@type string
-    tag = "@latest",
     -- gotests doesn't have template named "default" so this plugin uses "default" to set the default template
     template = "default",
     -- path to a directory containing custom test code templates

--- a/lua/gopher/config.lua
+++ b/lua/gopher/config.lua
@@ -27,6 +27,9 @@ local default_config = {
     -- path to a directory containing custom test code templates
     ---@type string|nil
     template_dir = nil,
+    -- switch table tests from using slice to map (with test name for the key)
+    ---@type boolean
+    named = false,
   },
   ---@class gopher.ConfigGoTag
   gotag = {

--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -6,6 +6,10 @@ local gotests = {}
 
 ---@param args table
 local function add_test(args)
+  if c.gotests.named then
+    table.insert(args, "-named")
+  end
+
   if c.gotests.template_dir then
     table.insert(args, "-template_dir")
     table.insert(args, c.gotests.template_dir)

--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -6,10 +6,6 @@ local gotests = {}
 
 ---@param args table
 local function add_test(args)
-  if c.gotests.named then
-    table.insert(args, "-named")
-  end
-
   if c.gotests.template_dir then
     table.insert(args, "-template_dir")
     table.insert(args, c.gotests.template_dir)

--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -6,7 +6,7 @@ local gotests = {}
 
 ---@param args table
 local function add_test(args)
-  if c.gotests.named then
+  if c.gotests.named ~= true then
     table.insert(args, "-named")
   end
 

--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -6,7 +6,7 @@ local gotests = {}
 
 ---@param args table
 local function add_test(args)
-  if c.gotests.named ~= true then
+  if c.gotests.named then
     table.insert(args, "-named")
   end
 

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -1,5 +1,4 @@
 local c = require("gopher.config").commands
-local c_gotests = require("gopher.config").gotests
 local r = require "gopher._utils.runner"
 local u = require "gopher._utils"
 local installer = {}
@@ -17,7 +16,7 @@ local latest_tag = "@latest"
 local tags = {
   gomodifytags = latest_tag,
   impl = latest_tag,
-  gotests = "@develop",
+  gotests = require("gopher.config").gotests.tag,
   iferr = latest_tag,
   dlv = latest_tag,
 }

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -1,4 +1,5 @@
 local c = require("gopher.config").commands
+local c_gotests = require("gopher.config").gotests
 local r = require "gopher._utils.runner"
 local u = require "gopher._utils"
 local installer = {}
@@ -11,9 +12,19 @@ local urls = {
   dlv = "github.com/go-delve/delve/cmd/dlv",
 }
 
+local latest_tag = "@latest"
+
+local tags = {
+  gomodifytags = latest_tag,
+  impl = latest_tag,
+  gotests = c_gotests.tag,
+  iferr = latest_tag,
+  dlv = latest_tag,
+}
+
 ---@param pkg string
 local function install(pkg)
-  local url = urls[pkg] .. "@latest"
+  local url = urls[pkg] .. tags[pkg]
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -13,7 +13,7 @@ local urls = {
 
 ---@param pkg string
 local function install(pkg)
-  local url = urls[pkg][1] .. "@latest"
+  local url = urls[pkg] .. "@latest"
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -17,7 +17,7 @@ local latest_tag = "@latest"
 local tags = {
   gomodifytags = latest_tag,
   impl = latest_tag,
-  gotests = c_gotests.tag,
+  gotests = "@develop",
   iferr = latest_tag,
   dlv = latest_tag,
 }
@@ -25,7 +25,6 @@ local tags = {
 ---@param pkg string
 local function install(pkg)
   local url = urls[pkg] .. tags[pkg]
-  u.notify("YEEET: " .. url)
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -3,19 +3,17 @@ local r = require "gopher._utils.runner"
 local u = require "gopher._utils"
 local installer = {}
 
-local latest = "@latest"
-
 local urls = {
-  gomodifytags = { "github.com/fatih/gomodifytags", latest },
-  impl = { "github.com/josharian/impl", latest },
-  gotests = { "github.com/cweill/gotests/...", require("gopher.config").gotests.tag },
-  iferr = { "github.com/koron/iferr", latest },
-  dlv = { "github.com/go-delve/delve/cmd/dlv", latest },
+  gomodifytags = "github.com/fatih/gomodifytags",
+  impl = "github.com/josharian/impl",
+  gotests = "github.com/cweill/gotests/...",
+  iferr = "github.com/koron/iferr",
+  dlv = "github.com/go-delve/delve/cmd/dlv",
 }
 
 ---@param pkg string
 local function install(pkg)
-  local url = urls[pkg][1] .. urls[pkg][2]
+  local url = urls[pkg][1] .. "@latest"
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -3,27 +3,19 @@ local r = require "gopher._utils.runner"
 local u = require "gopher._utils"
 local installer = {}
 
+local latest = "@latest"
+
 local urls = {
-  gomodifytags = "github.com/fatih/gomodifytags",
-  impl = "github.com/josharian/impl",
-  gotests = "github.com/cweill/gotests/...",
-  iferr = "github.com/koron/iferr",
-  dlv = "github.com/go-delve/delve/cmd/dlv",
-}
-
-local latest_tag = "@latest"
-
-local tags = {
-  gomodifytags = latest_tag,
-  impl = latest_tag,
-  gotests = require("gopher.config").gotests.tag,
-  iferr = latest_tag,
-  dlv = latest_tag,
+  gomodifytags = { "github.com/fatih/gomodifytags", latest },
+  impl = { "github.com/josharian/impl", latest },
+  gotests = { "github.com/cweill/gotests/...", require("gopher.config").gotests.tag },
+  iferr = { "github.com/koron/iferr", latest },
+  dlv = { "github.com/go-delve/delve/cmd/dlv", latest },
 }
 
 ---@param pkg string
 local function install(pkg)
-  local url = urls[pkg] .. tags[pkg]
+  local url = urls[pkg][1] .. urls[pkg][2]
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -25,7 +25,7 @@ local tags = {
 ---@param pkg string
 local function install(pkg)
   local url = urls[pkg] .. tags[pkg]
-  u.notify(url)
+  u.notify("YEEET: " .. url)
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)

--- a/lua/gopher/installer.lua
+++ b/lua/gopher/installer.lua
@@ -25,6 +25,7 @@ local tags = {
 ---@param pkg string
 local function install(pkg)
   local url = urls[pkg] .. tags[pkg]
+  u.notify(url)
   r.sync(c.go, {
     args = { "install", url },
     on_exit = function(data, status)


### PR DESCRIPTION
`-named` argument for gotests working only from develop branch. For some reason they're not merging it into main considering that a lot of time has passed I think gotests development not active at all atm. Because of that to make this arg work we need to add support for selecting gotests tag to install from.

Problem: hardcoding `@develop` tag in `urls` table works but if trying to get tag from gotests config there is always default value imported only.
