### PR TITLE
Fix: #51: Add beginning and end delimiters to -only param to avoid unwanted test function generation.

### DIFF
--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -39,7 +39,7 @@ function gotests.func_test()
     return
   end
 
-  add_test { "-only", ns.name }
+  add_test { "-only", "^" .. ns.name .. "$" }
 end
 
 ---generate unit tests for all functions in current file


### PR DESCRIPTION
Fixes #51

Please let me know if this is not the right place to fix this, or is not something you want in your plugin.