### PR TITLE
feat: allow gotests -template_dir argument customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ require("gopher").setup {
     impl = "impl",
     iferr = "iferr",
   },
+  gotests = {
+    template_dir = "" -- customize gotests -template_dir argument
+  }
 }
 ```
 

--- a/lua/gopher/config.lua
+++ b/lua/gopher/config.lua
@@ -21,6 +21,10 @@ local M = {
       iferr = "iferr",
       dlv = "dlv",
     },
+    gotests_args = {
+      ---override gotests templates
+      template_dir = "",
+    },
   },
 }
 

--- a/lua/gopher/gotests.lua
+++ b/lua/gopher/gotests.lua
@@ -22,6 +22,11 @@ end
 
 ---@param args table
 local function add_test(args)
+  local c = require("gopher.config").config.gotests
+  if c.template_dir ~= "" then
+    table.insert(args, "-template_dir")
+    table.insert(args, c.template_dir)
+  end
   local fpath = vim.fn.expand "%" ---@diagnostic disable-line: missing-parameter
   table.insert(args, "-w")
   table.insert(args, fpath)


### PR DESCRIPTION
Makes it possible to customize `-template_dir` argument for `gotests` utility.