### PR TITLE
chore: remove nvim-treesitter from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's **NOT** an LSP tool, the main goal of this plugin is to add go tooling supp
 Requirements:
 
 - **Neovim 0.10** or later
-- Treesitter `go` parser(`:TSInstall go`)
+- Treesitter `go` parser(`:TSInstall go` if you use [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter))
 - [Go](https://github.com/golang/go) installed (tested on 1.23)
 
 ```lua
@@ -21,9 +21,6 @@ Requirements:
   "olexsmir/gopher.nvim",
   ft = "go",
   -- branch = "develop"
-  dependencies = {
-    "nvim-treesitter/nvim-treesitter",
-  },
   -- (optional) will update plugin's deps on every update
   build = function()
     vim.cmd.GoInstallDeps()

--- a/lua/gopher/health.lua
+++ b/lua/gopher/health.lua
@@ -2,9 +2,6 @@ local health = {}
 local cmd = require("gopher.config").commands
 
 local deps = {
-  plugin = {
-    { lib = "nvim-treesitter", msg = "required for everything in gopher.nvim" },
-  },
   bin = {
     {
       bin = cmd.go,
@@ -25,13 +22,6 @@ local deps = {
   },
 }
 
----@param module string
----@return boolean
-local function is_lualib_found(module)
-  local is_found, _ = pcall(require, module)
-  return is_found
-end
-
 ---@param bin string
 ---@return boolean
 local function is_binary_found(bin)
@@ -46,15 +36,6 @@ local function is_treesitter_parser_available(ft)
 end
 
 function health.check()
-  vim.health.start "required plugins"
-  for _, plugin in ipairs(deps.plugin) do
-    if is_lualib_found(plugin.lib) then
-      vim.health.ok(plugin.lib .. " installed")
-    else
-      vim.health.error(plugin.lib .. " not found, " .. plugin.msg)
-    end
-  end
-
   vim.health.start "required binaries"
   vim.health.info "all those binaries can be installed by `:GoInstallDeps`"
   for _, bin in ipairs(deps.bin) do

--- a/pkg.json
+++ b/pkg.json
@@ -6,8 +6,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/olexsmir/gopher.nvim"
-  },
-  "dependencies": {
-    "https://github.com/nvim-treesitter/nvim-treesitter": "*"
   }
 }


### PR DESCRIPTION
Since, the plugin does not depend directly on nvim-treesitter, I decided to delete it, since user can decide for themselves how to install the `go` parser.
nvim-treesitter is still used in tests because i still find it the easiest way to install treesitter parsers.
